### PR TITLE
fix build generate_cloudevent_library script now stops on errors

### DIFF
--- a/scripts/generate_cloudevent_library.dart
+++ b/scripts/generate_cloudevent_library.dart
@@ -17,11 +17,15 @@ void main(List<String> arguments) async {
   if (fileSymbols.isEmpty) {
     logger.severe('Found no files to export');
     exitCode = 1;
+    return;
   }
 
   if (!await generateLibraryFiles(fileSymbols, libDirectoryPath)) {
+    logger.severe('Failed to generate the library files');
     exitCode = 1; // Propagate error state as a non-zero exit code
+    return;
   }
+
   logger.info('Exported symbols to library files');
 }
 


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes exiting the build script script after an error

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
